### PR TITLE
Add cards from 2022 and 2023 Mini-Tournament Packs

### DIFF
--- a/card.txt
+++ b/card.txt
@@ -313,3 +313,45 @@ wpww6
 rgw4y
 w4w5g
 PromoGenCon2023B
+Tourney'22 - Passion
+6
+Pw2w6
+www1w
+42wB3
+2ww4Y
+Tourney2022_1
+Tourney'22 - Life
+6
+26GwR
+1wwAw
+wA6YB
+4Y3w6
+Tourney2022_2
+Tourney'22 - Glory
+6
+2GRw1
+Bw1ww
+ww6wG
+ww5P4
+Tourney2022_3
+Tourney'23 - Passion
+6
+BwPww
+p5wwY
+3BwYG
+w2Rww
+Tourney2023_1
+Tourney'23 - Life
+6
+B32Gw
+YRwAw
+wA5wR
+w2G3w
+Tourney2023_2
+Tourney'23 - Glory
+6
+R2Yww
+BwwG3
+ww4wR
+Y6wwB
+Tourney2023_3


### PR DESCRIPTION
Requires #4 to be merged first.
Name of cards are shortened from the original, because with the current font, the text gets too wide.