### PR TITLE
Add speculation for Promo 24 (Tantrum House Season 10)

### DIFF
--- a/card.txt
+++ b/card.txt
@@ -313,3 +313,17 @@ wpww6
 rgw4y
 w4w5g
 PromoGenCon2023B
+Tantrum House*
+4
+2w4B3
+wBw32
+w3w26
+w12ww
+Promo24A
+Floodgate games**
+4
+Rww64
+wB4w2
+w4wR5
+ww61w
+Promo24B


### PR DESCRIPTION
This is a speculation for the card that expected to be released by September 2024.

The speculation is based on the following image: https://ksr-ugc.imgix.net/assets/042/326/795/fc60497016bb384cd07f9db33d3583c7_original.jpg?ixlib=rb-4.1.0&w=680&fit=max&v=1694890066&gif-q=50&q=92&s=44d5b41697e970214366a047e90eba32 (from https://www.kickstarter.com/projects/tantrumhouse/tantrum-house-season-10-board-game-media).

Names do include asterisks to indicate that this is a speculation for the unreleased card.
Second side has two asterisks to indicate that the side B is even a bigger speculation, because the Favor Token cost is not known (but I am pretty sure about that "1" in the bottom of the 4th column).

I guess, the other side Favor Token cost could be 4 as well. We can correct it as more information comes out.