### PR TITLE
Fix issue when running on case sensitive file system & added more windows

### DIFF
--- a/card.txt
+++ b/card.txt
@@ -306,6 +306,34 @@ wpww6
 rgw4y
 w4w5g
 2023GenConPromoB
+Tantrum House
+4
+2w4B3
+wBw32
+w3w26
+w12ww
+24A
+Floodgate games
+4
+Rww64
+wB4w2
+w4wR5
+ww61w
+24B
+2024 Gen Con Promo
+4
+ww6p3
+rwwg6
+4pww2
+5ywww
+2024GenConPromoA
+2024 Gen Con Promo
+4
+w1ww5
+ywbww
+w5w3g
+b2ww3
+2024GenConPromoB
 2022 Promo Pack
 5
 2www4
@@ -326,18 +354,46 @@ w2y3w
 bw1ww
 ww6wg
 ww5p4
-Glory
+2022Glory
 2022 Passion
 6
 pw2w6
 www1w
 42wb3
 2ww4y
-Passion
+2022Passion
 2022 Life
 6
 26gwr
 1wwww
 ww6yb
 4y3w6
-Life
+2022Life
+2023 Glory
+6
+2GRw1
+Bw1ww
+ww6wG
+ww5P4
+2023Glory
+2023 Passion
+6
+BwPww
+p5wwY
+3BwYG
+w2Rww
+2023Passion
+2023 Life
+6
+B32Gw
+YRwAw
+wA5wR
+w2G3w
+2023Life
+2023 Glory
+6
+R2Yww
+BwwG3
+ww4wR
+Y6wwB
+2023Glory

--- a/sagrada_generator.py
+++ b/sagrada_generator.py
@@ -20,7 +20,7 @@ class CardGenerator:
         for row in range(4):
             row_line = parameter_file.readline().strip()
             for column in range(5):
-                tile_image = Image.open(f'{row_line[column]}.png')
+                tile_image = Image.open(f'{row_line[column].upper()}.png')
                 (height, width) = tile_image.size
                 pos = (25 * (column + 1) + width * column, 20 * (row + 1) + height * row)
                 img.paste(tile_image, pos)


### PR DESCRIPTION
When running on a case sensitive file system it fails as the filenames are uppercase but the letters are often lowercase in cards.txt, so I changed the script to call `upper()`

Also added Promo 24 Tantrum House, 2024 Gen Con Promo and 2023 Mini Tournament windows